### PR TITLE
Fixes build issues with latest dependencies.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -17,7 +17,7 @@ runner = "espflash flash --monitor -b 2000000 "
 
 [env]
 ESP_IDF_SDKCONFIG_DEFAULTS = "sdkconfig.defaults"
-ESP_IDF_VERSION = "release/v4.4"
+ESP_IDF_VERSION = "v4.4.4"
 
 ESP_IDF_GLOB_CONFIG_FILES_BASE = { value = ".", relative = true }
 ESP_IDF_GLOB_CONFIG_FILES_1 = { value = "/partitions.csv" }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 #file: noinspection SpellCheckingInspection,SpellCheckingInspection,SpellCheckingInspection,SpellCheckingInspection
 name: build
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   rust_toolchain: nightly
@@ -17,8 +17,9 @@ jobs:
           - xtensa-esp32-espidf
           - xtensa-esp32s2-espidf
           - xtensa-esp32s3-espidf
-        idf-version:
-          - release/v4.4
+        idf-version:        
+          - v4.4.3
+          - v4.4.4
           - release/v5.0
     steps:
       - name: Setup | Checkout

--- a/src/gatt_server/custom_attributes.rs
+++ b/src/gatt_server/custom_attributes.rs
@@ -1,9 +1,9 @@
-use std::sync::{Arc, Mutex};
-
 use crate::{
     gatt_server::Descriptor,
     utilities::{AttributePermissions, BleUuid},
 };
+
+use std::sync::{Arc, Mutex};
 
 use esp_idf_svc::nvs::{EspDefaultNvs, EspDefaultNvsPartition};
 use lazy_static::lazy_static;

--- a/src/gatt_server/mod.rs
+++ b/src/gatt_server/mod.rs
@@ -233,6 +233,7 @@ impl GattServer {
             pcm_polar: CONFIG_BTDM_CTRL_PCM_POLAR_EFF as _,
             hli: BTDM_CTRL_HLI != 0,
             magic: ESP_BT_CONTROLLER_CONFIG_MAGIC_VAL,
+            #[cfg(any(esp_idf_version = "5.0", esp_idf_version = "5.1"))]
             dup_list_refresh_period: SCAN_DUPL_CACHE_REFRESH_PERIOD as u16,
         };
 
@@ -258,24 +259,39 @@ impl GattServer {
             txant_dft: CONFIG_BT_CTRL_TX_ANTENNA_INDEX_EFF as u8,
             rxant_dft: CONFIG_BT_CTRL_RX_ANTENNA_INDEX_EFF as u8,
             txpwr_dft: CONFIG_BT_CTRL_DFT_TX_POWER_LEVEL_EFF as u8,
+            #[cfg(any(esp_idf_version = "5.1"))]
+            cfg_mask: CFG_MASK,
+            #[cfg(any(
+                esp_idf_version_full = "4.4.3",
+                esp_idf_version_full = "4.4.4",
+                esp_idf_version = "5.0"
+            ))]
             cfg_mask: CFG_NASK,
             scan_duplicate_mode: SCAN_DUPLICATE_MODE as u8,
             scan_duplicate_type: SCAN_DUPLICATE_TYPE_VALUE as u8,
             normal_adv_size: NORMAL_SCAN_DUPLICATE_CACHE_SIZE as u16,
             mesh_adv_size: MESH_DUPLICATE_SCAN_CACHE_SIZE as u16,
             coex_phy_coded_tx_rx_time_limit: CONFIG_BT_CTRL_COEX_PHY_CODED_TX_RX_TLIM_EFF as u8,
-            #[cfg(any(esp_idf_version = "4.4", esp_idf_version = "5.0"))]
+            #[cfg(any(
+                esp_idf_version_full = "4.4.3",
+                esp_idf_version_full = "4.4.4",
+                esp_idf_version = "5.0"
+            ))]
             hw_target_code: BLE_HW_TARGET_CODE_ESP32C3_CHIP_ECO0,
-            #[cfg(esp_idf_version = "5.1")]
+            #[cfg(any(esp_idf_version = "5.1"))]
             hw_target_code: BLE_HW_TARGET_CODE_CHIP_ECO0,
             slave_ce_len_min: SLAVE_CE_LEN_MIN_DEFAULT as u8,
             hw_recorrect_en: AGC_RECORRECT_EN as u8,
             cca_thresh: CONFIG_BT_CTRL_HW_CCA_VAL as u8,
-            // #[cfg(any(esp_idf_version = "5.0", esp_idf_version = "5.1"))]
+            #[cfg(any(
+                esp_idf_version_full = "4.4.4",
+                esp_idf_version = "5.0",
+                esp_idf_version = "5.1"
+            ))]
             scan_backoff_upperlimitmax: BT_CTRL_SCAN_BACKOFF_UPPERLIMITMAX as u16,
-            // #[cfg(any(esp_idf_version = "5.0", esp_idf_version = "5.1"))]
+            #[cfg(any(esp_idf_version = "5.0", esp_idf_version = "5.1"))]
             dup_list_refresh_period: DUPL_SCAN_CACHE_REFRESH_PERIOD as u16,
-            #[cfg(esp_idf_version = "5.1")]
+            #[cfg(any(esp_idf_version = "5.1"))]
             ble_50_feat_supp: BT_CTRL_50_FEATURE_SUPPORT != 0,
         };
 
@@ -307,6 +323,7 @@ impl GattServer {
             normal_adv_size: NORMAL_SCAN_DUPLICATE_CACHE_SIZE as u16,
             mesh_adv_size: MESH_DUPLICATE_SCAN_CACHE_SIZE as u16,
             coex_phy_coded_tx_rx_time_limit: CONFIG_BT_CTRL_COEX_PHY_CODED_TX_RX_TLIM_EFF as u8,
+
             #[cfg(any(esp_idf_version = "4.4", esp_idf_version = "5.0"))]
             hw_target_code: BLE_HW_TARGET_CODE_ESP32S3_CHIP_ECO0,
             #[cfg(esp_idf_version = "5.1")]
@@ -314,10 +331,16 @@ impl GattServer {
             slave_ce_len_min: SLAVE_CE_LEN_MIN_DEFAULT as u8,
             hw_recorrect_en: AGC_RECORRECT_EN as u8,
             cca_thresh: CONFIG_BT_CTRL_HW_CCA_VAL as u8,
+            #[cfg(any(
+                esp_idf_version_full = "4.4.4",
+                esp_idf_version = "5.0",
+                esp_idf_version = "5.1"
+            ))]
             scan_backoff_upperlimitmax: BT_CTRL_SCAN_BACKOFF_UPPERLIMITMAX as u16,
+            #[cfg(any(esp_idf_version = "5.0", esp_idf_version = "5.1"))]
             dup_list_refresh_period: DUPL_SCAN_CACHE_REFRESH_PERIOD as u16,
-            #[cfg(esp_idf_version = "5.1")]
-            ble_50_feat_supp: BT_CTRL_50_FEATURE_SUPPORT != 0,
+            #[cfg(any(esp_idf_version = "5.1"))]
+            ble_50_feat_supp: EXT_CSD_SEC_FEATURE_SUPPORT != 0,
         };
         // BLE controller initialisation.
         unsafe {


### PR DESCRIPTION
Upon upgrading to the latest version of this package, I ran into a couple of issues compiling. In `mod.rs`, there was a specific field that needed to be flagged for > ESP-IDF 5.0 for the esp32-c3.

I was a bit unsure how the other error was actually introduced. I wasn't able to discover why this mattered only in the recent version of `esp-idf-sys`.

```
error[E0624]: method `set_raw` is private
  --> bluedroid\src\gatt_server\custom_attributes.rs:99:22
   |
99 |                     .set_raw(&key, &value)
   |                      ^^^^^^^ private method
  --> C:\Users\developer\.cargo\registry\src\index.crates.io-6f17d22bba15001f\esp-idf-svc-0.45.0\src\nvs.rs:329:5  
   |
   = note: private method defined here
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
1  | use embedded_svc::storage::RawStorage;
   |

For more information about this error, try `rustc --explain E0624`.
error: could not compile `bluedroid` (lib) due to previous error
```