### PR TITLE
Fixed `set_value` is a private method error. Related to #17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,4 +49,4 @@ opt-level = "z"
 lto = true
 
 [patch.crates-io]
-esp-idf-svc = { git = "https://github.com/esp-rs/esp-idf-svc.git", version = "0.45.0" }
+esp-idf-svc = { git = "https://github.com/esp-rs/esp-idf-svc.git", tag = "v0.45.0"}

--- a/src/gatt_server/custom_attributes.rs
+++ b/src/gatt_server/custom_attributes.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 
 use std::sync::{Arc, Mutex};
+use embedded_svc::storage::RawStorage;
 
 use esp_idf_svc::nvs::{EspDefaultNvs, EspDefaultNvsPartition};
 use lazy_static::lazy_static;


### PR DESCRIPTION
Thank you for creating this crate. It has been a valuable tool for my project, allowing me to meet the deadline without resorting to writing it in cpp.

I encountered a similar issue as @cwoolum in #17, but unfortunately, the fix provided didn't resolve it for me. 

After pulling the commit, I still experienced the problem mentioned in #17.

Fortunately, rustc provided a clear suggestion to use the `embedded_svc::storage::RawStorage` trait, which successfully resolved the issue for me. I hope this pull request proves helpful to others as well.
